### PR TITLE
GH-87: [Vector] Add ExtensionWriter (#697)

### DIFF
--- a/vector/src/main/codegen/templates/AbstractFieldWriter.java
+++ b/vector/src/main/codegen/templates/AbstractFieldWriter.java
@@ -107,6 +107,16 @@ abstract class AbstractFieldWriter extends AbstractBaseWriter implements FieldWr
     throw new IllegalStateException(String.format("You tried to end a map entry when you are using a ValueWriter of type %s.", this.getClass().getSimpleName()));
   }
 
+  public void write(ExtensionHolder var1)  {
+    this.fail("ExtensionType");
+  }
+  public void writeExtension(Object var1)  {
+    this.fail("ExtensionType");
+  }
+  public void addExtensionTypeWriterFactory(ExtensionTypeWriterFactory var1) {
+    this.fail("ExtensionType");
+  }
+
   <#list vv.types as type><#list type.minor as minor><#assign name = minor.class?cap_first />
   <#assign fields = minor.fields!type.fields />
   <#assign friendlyType = (minor.friendlyType!minor.boxedType!type.boxedType) />
@@ -239,6 +249,18 @@ abstract class AbstractFieldWriter extends AbstractBaseWriter implements FieldWr
   @Override
   public MapWriter map(String name, boolean keysSorted) {
     fail("Map");
+    return null;
+  }
+
+  @Override
+  public ExtensionWriter extension(String name, ArrowType arrowType) {
+    fail("Extension");
+    return null;
+  }
+
+  @Override
+  public ExtensionWriter extension(ArrowType arrowType) {
+    fail("Extension");
     return null;
   }
   <#list vv.types as type><#list type.minor as minor>

--- a/vector/src/main/codegen/templates/AbstractPromotableFieldWriter.java
+++ b/vector/src/main/codegen/templates/AbstractPromotableFieldWriter.java
@@ -294,6 +294,11 @@ abstract class AbstractPromotableFieldWriter extends AbstractFieldWriter {
   }
 
   @Override
+  public ExtensionWriter extension(ArrowType arrowType) {
+    return getWriter(MinorType.EXTENSIONTYPE).extension(arrowType);
+  }
+
+  @Override
   public StructWriter struct(String name) {
     return getWriter(MinorType.STRUCT).struct(name);
   }
@@ -316,6 +321,11 @@ abstract class AbstractPromotableFieldWriter extends AbstractFieldWriter {
   @Override
   public MapWriter map(String name, boolean keysSorted) {
     return getWriter(MinorType.STRUCT).map(name, keysSorted);
+  }
+
+  @Override
+  public ExtensionWriter extension(String name, ArrowType arrowType) {
+    return getWriter(MinorType.EXTENSIONTYPE).extension(name, arrowType);
   }
 
   <#list vv.types as type><#list type.minor as minor>

--- a/vector/src/main/codegen/templates/BaseWriter.java
+++ b/vector/src/main/codegen/templates/BaseWriter.java
@@ -61,6 +61,7 @@ public interface BaseWriter extends AutoCloseable, Positionable {
 
     void copyReaderToField(String name, FieldReader reader);
     StructWriter struct(String name);
+    ExtensionWriter extension(String name, ArrowType arrowType);
     ListWriter list(String name);
     ListWriter listView(String name);
     MapWriter map(String name);
@@ -79,6 +80,7 @@ public interface BaseWriter extends AutoCloseable, Positionable {
     ListWriter listView();
     MapWriter map();
     MapWriter map(boolean keysSorted);
+    ExtensionWriter extension(ArrowType arrowType);
     void copyReader(FieldReader reader);
 
     <#list vv.types as type><#list type.minor as minor>
@@ -99,6 +101,35 @@ public interface BaseWriter extends AutoCloseable, Positionable {
 
     MapWriter key();
     MapWriter value();
+  }
+
+  public interface ExtensionWriter extends BaseWriter {
+
+    /**
+     * Writes a null value.
+     */
+    void writeNull();
+
+    /**
+     * Writes value from the given extension holder.
+     *
+     * @param holder the extension holder to write
+     */
+    void write(ExtensionHolder holder);
+
+    /**
+     * Writes the given extension type value.
+     *
+     * @param value the extension type value to write
+     */
+    void writeExtension(Object value);
+
+    /**
+     * Adds the given extension type factory. This factory allows configuring writer implementations for specific ExtensionTypeVector.
+     *
+     * @param factory the extension type factory to add
+     */
+    void addExtensionTypeWriterFactory(ExtensionTypeWriterFactory factory);
   }
 
   public interface ScalarWriter extends

--- a/vector/src/main/codegen/templates/PromotableWriter.java
+++ b/vector/src/main/codegen/templates/PromotableWriter.java
@@ -285,6 +285,9 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
       case UNION:
         writer = new UnionWriter((UnionVector) vector, nullableStructWriterFactory);
         break;
+      case EXTENSIONTYPE:
+        writer = new UnionExtensionWriter((ExtensionTypeVector) vector);
+        break;
       default:
         writer = type.getNewFieldWriter(vector);
         break;
@@ -316,6 +319,7 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
         || type == MinorType.MAP
         || type == MinorType.DURATION
         || type == MinorType.FIXEDSIZEBINARY
+        || type == MinorType.EXTENSIONTYPE
         || (type.name().startsWith("TIMESTAMP") && type.name().endsWith("TZ"));
   }
 
@@ -534,6 +538,16 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
   @Override
   public void writeLargeVarChar(String value) {
     getWriter(MinorType.LARGEVARCHAR).writeLargeVarChar(value);
+  }
+
+  @Override
+  public void writeExtension(Object value) {
+    getWriter(MinorType.EXTENSIONTYPE).writeExtension(value);
+  }
+
+  @Override
+  public void addExtensionTypeWriterFactory(ExtensionTypeWriterFactory factory) {
+    getWriter(MinorType.EXTENSIONTYPE).addExtensionTypeWriterFactory(factory);
   }
 
   @Override

--- a/vector/src/main/codegen/templates/UnionListWriter.java
+++ b/vector/src/main/codegen/templates/UnionListWriter.java
@@ -201,6 +201,17 @@ public class Union${listName}Writer extends AbstractFieldWriter {
     return mapWriter;
   }
 
+  @Override
+  public ExtensionWriter extension(ArrowType arrowType) {
+    writer.extension(arrowType);
+    return writer;
+  }
+  @Override
+  public ExtensionWriter extension(String name, ArrowType arrowType) {
+    ExtensionWriter extensionWriter = writer.extension(name, arrowType);
+    return extensionWriter;
+  }
+
   <#if listName == "LargeList">
   @Override
   public void startList() {
@@ -321,6 +332,18 @@ public class Union${listName}Writer extends AbstractFieldWriter {
     } else {
       writer.writeNull();
     }
+  }
+
+  @Override
+  public void writeExtension(Object value) {
+    writer.writeExtension(value);
+  }
+  @Override
+  public void addExtensionTypeWriterFactory(ExtensionTypeWriterFactory var1) {
+    writer.addExtensionTypeWriterFactory(var1);
+  }
+  public void write(ExtensionHolder var1) {
+    writer.write(var1);
   }
 
   <#list vv.types as type>

--- a/vector/src/main/codegen/templates/UnionMapWriter.java
+++ b/vector/src/main/codegen/templates/UnionMapWriter.java
@@ -231,4 +231,16 @@ public class UnionMapWriter extends UnionListWriter {
         return super.map();
     }
   }
+
+  @Override
+  public ExtensionWriter extension(ArrowType type) {
+    switch (mode) {
+      case KEY:
+        return entryWriter.extension(MapVector.KEY_NAME, type);
+      case VALUE:
+        return entryWriter.extension(MapVector.VALUE_NAME, type);
+      default:
+        return super.extension(type);
+    }
+  }
 }

--- a/vector/src/main/codegen/templates/UnionWriter.java
+++ b/vector/src/main/codegen/templates/UnionWriter.java
@@ -213,6 +213,10 @@ public class UnionWriter extends AbstractFieldWriter implements FieldWriter {
     return getMapWriter(arrowType);
   }
 
+  private ExtensionWriter getExtensionWriter(ArrowType arrowType) {
+    throw new UnsupportedOperationException("ExtensionTypes are not supported yet.");
+  }
+
   BaseWriter getWriter(MinorType minorType) {
     return getWriter(minorType, null);
   }
@@ -227,6 +231,8 @@ public class UnionWriter extends AbstractFieldWriter implements FieldWriter {
       return getListViewWriter();
     case MAP:
       return getMapWriter(arrowType);
+    case EXTENSIONTYPE:
+      return getExtensionWriter(arrowType);
     <#list vv.types as type>
       <#list type.minor as minor>
         <#assign name = minor.class?cap_first />
@@ -458,6 +464,20 @@ public class UnionWriter extends AbstractFieldWriter implements FieldWriter {
     data.setType(idx(), MinorType.MAP);
     getStructWriter().setPosition(idx());
     return getStructWriter().map(name, keysSorted);
+  }
+
+  @Override
+  public ExtensionWriter extension(ArrowType arrowType) {
+    data.setType(idx(), MinorType.EXTENSIONTYPE);
+    getListWriter().setPosition(idx());
+    return getListWriter().extension(arrowType);
+  }
+
+  @Override
+  public ExtensionWriter extension(String name, ArrowType arrowType) {
+    data.setType(idx(), MinorType.EXTENSIONTYPE);
+    getStructWriter().setPosition(idx());
+    return getStructWriter().extension(name, arrowType);
   }
 
   <#list vv.types as type><#list type.minor as minor>

--- a/vector/src/main/java/org/apache/arrow/vector/complex/impl/AbstractExtensionTypeWriter.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/impl/AbstractExtensionTypeWriter.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.arrow.vector.complex.impl;
+
+import org.apache.arrow.vector.ExtensionTypeVector;
+import org.apache.arrow.vector.types.pojo.Field;
+
+/**
+ * Base {@link AbstractFieldWriter} class for an {@link
+ * org.apache.arrow.vector.ExtensionTypeVector}.
+ *
+ * @param <T> a specific {@link ExtensionTypeVector}.
+ */
+public class AbstractExtensionTypeWriter<T extends ExtensionTypeVector>
+    extends AbstractFieldWriter {
+  protected final T vector;
+
+  public AbstractExtensionTypeWriter(T vector) {
+    this.vector = vector;
+  }
+
+  @Override
+  public Field getField() {
+    return this.vector.getField();
+  }
+
+  @Override
+  public int getValueCapacity() {
+    return this.vector.getValueCapacity();
+  }
+
+  @Override
+  public void allocate() {
+    this.vector.allocateNew();
+  }
+
+  @Override
+  public void close() {
+    this.vector.close();
+  }
+
+  @Override
+  public void clear() {
+    this.vector.clear();
+  }
+
+  @Override
+  public void writeNull() {
+    this.vector.setNull(getPosition());
+    this.vector.setValueCount(getPosition() + 1);
+  }
+}

--- a/vector/src/main/java/org/apache/arrow/vector/complex/impl/ExtensionTypeWriterFactory.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/impl/ExtensionTypeWriterFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.arrow.vector.complex.impl;
+
+import org.apache.arrow.vector.ExtensionTypeVector;
+import org.apache.arrow.vector.complex.writer.FieldWriter;
+
+/**
+ * A factory interface for creating instances of {@link ExtensionTypeWriter}. This factory allows
+ * configuring writer implementations for specific {@link ExtensionTypeVector}.
+ *
+ * @param <T> the type of writer implementation for a specific {@link ExtensionTypeVector}.
+ */
+public interface ExtensionTypeWriterFactory<T extends FieldWriter> {
+
+  /**
+   * Returns an instance of the writer implementation for the given {@link ExtensionTypeVector}.
+   *
+   * @param vector the {@link ExtensionTypeVector} for which the writer implementation is to be
+   *     returned.
+   * @return an instance of the writer implementation for the given {@link ExtensionTypeVector}.
+   */
+  T getWriterImpl(ExtensionTypeVector vector);
+}

--- a/vector/src/main/java/org/apache/arrow/vector/complex/impl/UnionExtensionWriter.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/impl/UnionExtensionWriter.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.arrow.vector.complex.impl;
+
+import org.apache.arrow.vector.ExtensionTypeVector;
+import org.apache.arrow.vector.complex.writer.FieldWriter;
+import org.apache.arrow.vector.holders.ExtensionHolder;
+import org.apache.arrow.vector.types.pojo.Field;
+
+public class UnionExtensionWriter extends AbstractFieldWriter {
+  protected ExtensionTypeVector vector;
+  protected FieldWriter writer;
+
+  public UnionExtensionWriter(ExtensionTypeVector vector) {
+    this.vector = vector;
+  }
+
+  @Override
+  public void allocate() {
+    vector.allocateNew();
+  }
+
+  @Override
+  public void clear() {
+    vector.clear();
+  }
+
+  @Override
+  public int getValueCapacity() {
+    return vector.getValueCapacity();
+  }
+
+  @Override
+  public Field getField() {
+    return vector.getField();
+  }
+
+  @Override
+  public void close() throws Exception {
+    vector.close();
+  }
+
+  @Override
+  public void writeExtension(Object var1) {
+    this.writer.writeExtension(var1);
+  }
+
+  @Override
+  public void addExtensionTypeWriterFactory(ExtensionTypeWriterFactory factory) {
+    this.writer = factory.getWriterImpl(vector);
+    this.writer.setPosition(idx());
+  }
+
+  public void write(ExtensionHolder holder) {
+    this.writer.write(holder);
+  }
+
+  @Override
+  public void setPosition(int index) {
+    super.setPosition(index);
+    if (this.writer != null) {
+      this.writer.setPosition(index);
+    }
+  }
+}

--- a/vector/src/main/java/org/apache/arrow/vector/holders/ExtensionHolder.java
+++ b/vector/src/main/java/org/apache/arrow/vector/holders/ExtensionHolder.java
@@ -14,21 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.arrow.vector.complex.writer;
+package org.apache.arrow.vector.holders;
 
-import org.apache.arrow.vector.complex.writer.BaseWriter.ExtensionWriter;
-import org.apache.arrow.vector.complex.writer.BaseWriter.ListWriter;
-import org.apache.arrow.vector.complex.writer.BaseWriter.MapWriter;
-import org.apache.arrow.vector.complex.writer.BaseWriter.ScalarWriter;
-import org.apache.arrow.vector.complex.writer.BaseWriter.StructWriter;
-
-/**
- * Composite of all writer types. Writers are convenience classes for incrementally adding values to
- * {@linkplain org.apache.arrow.vector.ValueVector}s.
- */
-public interface FieldWriter
-    extends StructWriter, ListWriter, MapWriter, ScalarWriter, ExtensionWriter {
-  void allocate();
-
-  void clear();
+/** Base {@link ValueHolder} class for a {@link org.apache.arrow.vector.ExtensionTypeVector}. */
+public abstract class ExtensionHolder implements ValueHolder {
+  public int isSet;
 }

--- a/vector/src/test/java/org/apache/arrow/vector/UuidVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/UuidVector.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.arrow.vector;
+
+import java.nio.ByteBuffer;
+import java.util.UUID;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.util.hash.ArrowBufHasher;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.UuidType;
+import org.apache.arrow.vector.util.TransferPair;
+
+public class UuidVector extends ExtensionTypeVector<FixedSizeBinaryVector>
+    implements ValueIterableVector<UUID> {
+  private final Field field;
+
+  public UuidVector(
+      String name, BufferAllocator allocator, FixedSizeBinaryVector underlyingVector) {
+    super(name, allocator, underlyingVector);
+    this.field = new Field(name, FieldType.nullable(new UuidType()), null);
+  }
+
+  public UuidVector(String name, BufferAllocator allocator) {
+    super(name, allocator, new FixedSizeBinaryVector(name, allocator, 16));
+    this.field = new Field(name, FieldType.nullable(new UuidType()), null);
+  }
+
+  @Override
+  public UUID getObject(int index) {
+    final ByteBuffer bb = ByteBuffer.wrap(getUnderlyingVector().getObject(index));
+    return new UUID(bb.getLong(), bb.getLong());
+  }
+
+  @Override
+  public int hashCode(int index) {
+    return hashCode(index, null);
+  }
+
+  @Override
+  public int hashCode(int index, ArrowBufHasher hasher) {
+    return getUnderlyingVector().hashCode(index, hasher);
+  }
+
+  public void set(int index, UUID uuid) {
+    ByteBuffer bb = ByteBuffer.allocate(16);
+    bb.putLong(uuid.getMostSignificantBits());
+    bb.putLong(uuid.getLeastSignificantBits());
+    getUnderlyingVector().set(index, bb.array());
+  }
+
+  @Override
+  public void copyFromSafe(int fromIndex, int thisIndex, ValueVector from) {
+    getUnderlyingVector()
+        .copyFromSafe(fromIndex, thisIndex, ((UuidVector) from).getUnderlyingVector());
+  }
+
+  @Override
+  public Field getField() {
+    return field;
+  }
+
+  @Override
+  public TransferPair makeTransferPair(ValueVector to) {
+    return new TransferImpl((UuidVector) to);
+  }
+
+  public void setSafe(int index, byte[] value) {
+    getUnderlyingVector().setIndexDefined(index);
+    getUnderlyingVector().setSafe(index, value);
+  }
+
+  public class TransferImpl implements TransferPair {
+    UuidVector to;
+    ValueVector targetUnderlyingVector;
+    TransferPair tp;
+
+    public TransferImpl(UuidVector to) {
+      this.to = to;
+      targetUnderlyingVector = this.to.getUnderlyingVector();
+      tp = getUnderlyingVector().makeTransferPair(targetUnderlyingVector);
+    }
+
+    public UuidVector getTo() {
+      return this.to;
+    }
+
+    public void transfer() {
+      tp.transfer();
+    }
+
+    public void splitAndTransfer(int startIndex, int length) {
+      tp.splitAndTransfer(startIndex, length);
+    }
+
+    public void copyValueSafe(int fromIndex, int toIndex) {
+      tp.copyValueSafe(fromIndex, toIndex);
+    }
+  }
+}

--- a/vector/src/test/java/org/apache/arrow/vector/complex/impl/UuidWriterFactory.java
+++ b/vector/src/test/java/org/apache/arrow/vector/complex/impl/UuidWriterFactory.java
@@ -14,21 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.arrow.vector.complex.writer;
+package org.apache.arrow.vector.complex.impl;
 
-import org.apache.arrow.vector.complex.writer.BaseWriter.ExtensionWriter;
-import org.apache.arrow.vector.complex.writer.BaseWriter.ListWriter;
-import org.apache.arrow.vector.complex.writer.BaseWriter.MapWriter;
-import org.apache.arrow.vector.complex.writer.BaseWriter.ScalarWriter;
-import org.apache.arrow.vector.complex.writer.BaseWriter.StructWriter;
+import org.apache.arrow.vector.ExtensionTypeVector;
+import org.apache.arrow.vector.UuidVector;
 
-/**
- * Composite of all writer types. Writers are convenience classes for incrementally adding values to
- * {@linkplain org.apache.arrow.vector.ValueVector}s.
- */
-public interface FieldWriter
-    extends StructWriter, ListWriter, MapWriter, ScalarWriter, ExtensionWriter {
-  void allocate();
+public class UuidWriterFactory implements ExtensionTypeWriterFactory {
 
-  void clear();
+  @Override
+  public AbstractFieldWriter getWriterImpl(ExtensionTypeVector extensionTypeVector) {
+    if (extensionTypeVector instanceof UuidVector) {
+      return new UuidWriterImpl((UuidVector) extensionTypeVector);
+    }
+    return null;
+  }
 }

--- a/vector/src/test/java/org/apache/arrow/vector/complex/impl/UuidWriterImpl.java
+++ b/vector/src/test/java/org/apache/arrow/vector/complex/impl/UuidWriterImpl.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.arrow.vector.complex.impl;
+
+import java.nio.ByteBuffer;
+import java.util.UUID;
+import org.apache.arrow.vector.UuidVector;
+import org.apache.arrow.vector.holder.UuidHolder;
+import org.apache.arrow.vector.holders.ExtensionHolder;
+
+public class UuidWriterImpl extends AbstractExtensionTypeWriter<UuidVector> {
+
+  public UuidWriterImpl(UuidVector vector) {
+    super(vector);
+  }
+
+  @Override
+  public void writeExtension(Object value) {
+    UUID uuid = (UUID) value;
+    ByteBuffer bb = ByteBuffer.allocate(16);
+    bb.putLong(uuid.getMostSignificantBits());
+    bb.putLong(uuid.getLeastSignificantBits());
+    vector.setSafe(getPosition(), bb.array());
+    vector.setValueCount(getPosition() + 1);
+  }
+
+  @Override
+  public void write(ExtensionHolder holder) {
+    UuidHolder uuidHolder = (UuidHolder) holder;
+    vector.setSafe(getPosition(), uuidHolder.value);
+    vector.setValueCount(getPosition() + 1);
+  }
+}

--- a/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestSimpleWriter.java
+++ b/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestSimpleWriter.java
@@ -20,16 +20,20 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.ByteBuffer;
+import java.util.UUID;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.LargeVarBinaryVector;
 import org.apache.arrow.vector.LargeVarCharVector;
+import org.apache.arrow.vector.UuidVector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.complex.impl.LargeVarBinaryWriterImpl;
 import org.apache.arrow.vector.complex.impl.LargeVarCharWriterImpl;
+import org.apache.arrow.vector.complex.impl.UuidWriterImpl;
 import org.apache.arrow.vector.complex.impl.VarBinaryWriterImpl;
 import org.apache.arrow.vector.complex.impl.VarCharWriterImpl;
+import org.apache.arrow.vector.holder.UuidHolder;
 import org.apache.arrow.vector.util.Text;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -182,6 +186,22 @@ public class TestSimpleWriter {
       writer.writeLargeVarChar(new Text(input));
       String result = vector.getObject(0).toString();
       assertEquals(input, result);
+    }
+  }
+
+  @Test
+  public void testWriteToExtensionVector() throws Exception {
+    try (UuidVector vector = new UuidVector("test", allocator);
+        UuidWriterImpl writer = new UuidWriterImpl(vector)) {
+      UUID uuid = UUID.randomUUID();
+      ByteBuffer bb = ByteBuffer.allocate(16);
+      bb.putLong(uuid.getMostSignificantBits());
+      bb.putLong(uuid.getLeastSignificantBits());
+      UuidHolder holder = new UuidHolder();
+      holder.value = bb.array();
+      writer.write(holder);
+      UUID result = vector.getObject(0);
+      assertEquals(uuid, result);
     }
   }
 }

--- a/vector/src/test/java/org/apache/arrow/vector/holder/UuidHolder.java
+++ b/vector/src/test/java/org/apache/arrow/vector/holder/UuidHolder.java
@@ -14,21 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.arrow.vector.complex.writer;
+package org.apache.arrow.vector.holder;
 
-import org.apache.arrow.vector.complex.writer.BaseWriter.ExtensionWriter;
-import org.apache.arrow.vector.complex.writer.BaseWriter.ListWriter;
-import org.apache.arrow.vector.complex.writer.BaseWriter.MapWriter;
-import org.apache.arrow.vector.complex.writer.BaseWriter.ScalarWriter;
-import org.apache.arrow.vector.complex.writer.BaseWriter.StructWriter;
+import org.apache.arrow.vector.holders.ExtensionHolder;
 
-/**
- * Composite of all writer types. Writers are convenience classes for incrementally adding values to
- * {@linkplain org.apache.arrow.vector.ValueVector}s.
- */
-public interface FieldWriter
-    extends StructWriter, ListWriter, MapWriter, ScalarWriter, ExtensionWriter {
-  void allocate();
-
-  void clear();
+public class UuidHolder extends ExtensionHolder {
+  public byte[] value;
 }

--- a/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestExtensionType.java
+++ b/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestExtensionType.java
@@ -41,6 +41,7 @@ import org.apache.arrow.vector.ExtensionTypeVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.FixedSizeBinaryVector;
 import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.UuidVector;
 import org.apache.arrow.vector.ValueIterableVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.compare.Range;
@@ -292,75 +293,6 @@ public class TestExtensionType {
       VectorBatchAppender.batchAppend(a1, a2, bb);
       assertEquals(6, a1.getValueCount());
       validateVisitor.visit(a1, null);
-    }
-  }
-
-  static class UuidType extends ExtensionType {
-
-    @Override
-    public ArrowType storageType() {
-      return new ArrowType.FixedSizeBinary(16);
-    }
-
-    @Override
-    public String extensionName() {
-      return "uuid";
-    }
-
-    @Override
-    public boolean extensionEquals(ExtensionType other) {
-      return other instanceof UuidType;
-    }
-
-    @Override
-    public ArrowType deserialize(ArrowType storageType, String serializedData) {
-      if (!storageType.equals(storageType())) {
-        throw new UnsupportedOperationException(
-            "Cannot construct UuidType from underlying type " + storageType);
-      }
-      return new UuidType();
-    }
-
-    @Override
-    public String serialize() {
-      return "";
-    }
-
-    @Override
-    public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator) {
-      return new UuidVector(name, allocator, new FixedSizeBinaryVector(name, allocator, 16));
-    }
-  }
-
-  static class UuidVector extends ExtensionTypeVector<FixedSizeBinaryVector>
-      implements ValueIterableVector<UUID> {
-
-    public UuidVector(
-        String name, BufferAllocator allocator, FixedSizeBinaryVector underlyingVector) {
-      super(name, allocator, underlyingVector);
-    }
-
-    @Override
-    public UUID getObject(int index) {
-      final ByteBuffer bb = ByteBuffer.wrap(getUnderlyingVector().getObject(index));
-      return new UUID(bb.getLong(), bb.getLong());
-    }
-
-    @Override
-    public int hashCode(int index) {
-      return hashCode(index, null);
-    }
-
-    @Override
-    public int hashCode(int index, ArrowBufHasher hasher) {
-      return getUnderlyingVector().hashCode(index, hasher);
-    }
-
-    public void set(int index, UUID uuid) {
-      ByteBuffer bb = ByteBuffer.allocate(16);
-      bb.putLong(uuid.getMostSignificantBits());
-      bb.putLong(uuid.getLeastSignificantBits());
-      getUnderlyingVector().set(index, bb.array());
     }
   }
 

--- a/vector/src/test/java/org/apache/arrow/vector/types/pojo/UuidType.java
+++ b/vector/src/test/java/org/apache/arrow/vector/types/pojo/UuidType.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.arrow.vector.types.pojo;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.FixedSizeBinaryVector;
+import org.apache.arrow.vector.UuidVector;
+import org.apache.arrow.vector.types.pojo.ArrowType.ExtensionType;
+
+public class UuidType extends ExtensionType {
+
+  @Override
+  public ArrowType storageType() {
+    return new ArrowType.FixedSizeBinary(16);
+  }
+
+  @Override
+  public String extensionName() {
+    return "uuid";
+  }
+
+  @Override
+  public boolean extensionEquals(ExtensionType other) {
+    return other instanceof UuidType;
+  }
+
+  @Override
+  public ArrowType deserialize(ArrowType storageType, String serializedData) {
+    if (!storageType.equals(storageType())) {
+      throw new UnsupportedOperationException(
+          "Cannot construct UuidType from underlying type " + storageType);
+    }
+    return new UuidType();
+  }
+
+  @Override
+  public String serialize() {
+    return "";
+  }
+
+  @Override
+  public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator) {
+    return new UuidVector(name, allocator, new FixedSizeBinaryVector(name, allocator, 16));
+  }
+}


### PR DESCRIPTION
Based on changes from https://github.com/apache/arrow/pull/41731.

## What's Changed

Added writer ExtensionWriter with 3 methods:
- write method  for writing values from Extension holders;
- writeExtensionType method for writing values (arguments is Object because we don't know exact type);
- addExtensionTypeFactory method - because the exact vector and value type are unknown, the user should create their own extension type vector, write for it, and ExtensionTypeFactory, which should map the vector and writer.

Closes #87.
