### PR TITLE
DX-110305 Use vcpkg on mac builds to install llvm. This removes the z…

### DIFF
--- a/.github/workflows/jarbuild.yml
+++ b/.github/workflows/jarbuild.yml
@@ -158,7 +158,7 @@ jobs:
   jni-macos:
     name: JNI ${{ matrix.platform.runs_on }} ${{ matrix.platform.arch }}
     runs-on: ${{ matrix.platform.runs_on }}
-    timeout-minutes: 45
+    timeout-minutes: 445
     needs:
       - source
     strategy:
@@ -166,7 +166,7 @@ jobs:
       matrix:
         platform:
           - { runs_on: macos-15-intel, arch: "x86_64"}
-          - { runs_on: macos-14, arch: "aarch_64" }
+          - { runs_on: macos-15, arch: "aarch_64" }
     env:
       MACOSX_DEPLOYMENT_TARGET: "14.0"
     steps:
@@ -205,20 +205,19 @@ jobs:
           python-version: 3.12
       - name: Install Archery
         run: pip install -e arrow/dev/archery[all]
+      - name: Checkout vcpkg
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: Microsoft/vcpkg
+          path: arrow/cpp/submodules/vcpkg
+      - name: Install vcpkg
+        run: |
+          cd arrow/cpp/submodules/vcpkg
+          ./bootstrap-vcpkg.sh
+          echo "VCPKG_ROOT=${PWD}/arrow/cpp/submodules/vcpkg" >> ${GITHUB_ENV}
+          echo "${PWD}/arrow/cpp/submodules/vcpkg" >> ${GITHUB_PATH}
       - name: Install dependencies
         run: |
-          # We want to use llvm@14 to avoid shared z3
-          # dependency. llvm@14 doesn't depend on z3 and llvm depends
-          # on z3. And Homebrew's z3 provides only shared library. It
-          # doesn't provides static z3 because z3's CMake doesn't accept
-          # building both shared and static libraries at once.
-          # See also: Z3_BUILD_LIBZ3_SHARED in
-          # https://github.com/Z3Prover/z3/blob/master/README-CMake.md
-          #
-          # If llvm is installed, Apache Arrow C++ uses llvm rather than
-          # llvm@14 because llvm is newer than llvm@14.
-          brew uninstall llvm || :
-
           # Ensure updating python@XXX with the "--overwrite" option.
           # If python@XXX is updated without "--overwrite", it causes
           # a conflict error. Because Python 3 installed not by
@@ -240,7 +239,13 @@ jobs:
             brew uninstall pkg-config@0.29.2 || :
           fi
 
+          # Install basic build tools via brew (vcpkg needs these)
+          brew install cmake ninja pkg-config
           brew bundle --file=arrow/cpp/Brewfile
+
+          # Clean up any existing LLVM installations in favor of vcpkg.
+          brew uninstall llvm || :
+
           # We want to link aws-sdk-cpp statically but Homebrew's
           # aws-sdk-cpp provides only shared library. If we have
           # Homebrew's aws-sdk-cpp, our build mix Homebrew's
@@ -259,6 +264,14 @@ jobs:
           # bundled Protobuf.
           brew uninstall protobuf
 
+          # Use vcpkg to install LLVM.
+          vcpkg install \
+            --clean-after-build \
+            --x-install-root=${VCPKG_ROOT}/installed \
+            --x-manifest-root=arrow/ci/vcpkg \
+            --overlay-ports=arrow/ci/vcpkg/overlay/llvm/ \
+            --x-feature=gandiva-llvm
+            
           brew bundle --file=Brewfile
       - name: Prepare ccache
         run: |


### PR DESCRIPTION
…3 runtime dependency and ensures a consistent version of llvm with the linux builds.

## What's Changed

Please fill in a description of the changes here.


Closes #NNN.
