### PR TITLE
MINOR: Fix macOS build failures by making brew uninstall commands non-fatal

### DIFF
--- a/.github/workflows/jarbuild.yml
+++ b/.github/workflows/jarbuild.yml
@@ -246,18 +246,18 @@ jobs:
           # Homebrew's aws-sdk-cpp, our build mix Homebrew's
           # aws-sdk-cpp and bundled aws-sdk-cpp. We uninstall Homebrew's
           # aws-sdk-cpp to ensure using only bundled aws-sdk-cpp.
-          brew uninstall aws-sdk-cpp
+          brew uninstall aws-sdk-cpp || :
           # We want to use bundled RE2 for static linking. If
           # Homebrew's RE2 is installed, its header file may be used.
           # We uninstall Homebrew's RE2 to ensure using bundled RE2.
           brew uninstall grpc || : # gRPC depends on RE2
           brew uninstall grpc@1.54 || : # gRPC 1.54 may be installed too
-          brew uninstall re2
+          brew uninstall re2 || :
           # We want to use bundled Protobuf for static linking. If
           # Homebrew's Protobuf is installed, its library file may be
           # used on test  We uninstall Homebrew's Protobuf to ensure using
           # bundled Protobuf.
-          brew uninstall protobuf
+          brew uninstall protobuf || :
 
           brew bundle --file=Brewfile
       - name: Prepare ccache


### PR DESCRIPTION
The jarbuild workflow was failing on macOS because it tried to uninstall Homebrew formulas that don't exist or aren't installed:
- aws-sdk-cpp (may not be installed)
- re2 (may not be installed)
- protobuf (may not be installed)

These uninstall commands were failing with exit code 1, causing the entire build to fail. By adding '|| :' to these commands, we make them non-fatal so the build can continue even if the formulas aren't installed.

The grpc and grpc@1.54 uninstall commands already had '|| :' and were working correctly.