### PR TITLE
ARROW-XXXX: [Java] Make StructVector.reallocValidityBuffer protected

### DIFF
--- a/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
@@ -528,7 +528,7 @@ public class StructVector extends NonNullableStructVector
     super.reAlloc();
   }
 
-  private void reallocValidityBuffer() {
+  protected void reallocValidityBuffer() {
     final int currentBufferCapacity = checkedCastToInt(validityBuffer.capacity());
     long newAllocationSize = getNewAllocationSize(currentBufferCapacity);
 


### PR DESCRIPTION
ARROW-XXXX: [Java] Make StructVector.reallocValidityBuffer protected
Changes the access modifier of `reallocValidityBuffer` from package-private to protected.

This allows subclasses to reallocate the validity buffer independently of the struct elements. Previously,
expanding the validity buffer required a full vector reallocation, which could cause an `OversizedAllocationException`
if the child data vectors were already near their capacity.
