### PR TITLE
DX-114802: Improve build traceability and rename jar files

### DIFF
--- a/.github/workflows/jarbuild.yml
+++ b/.github/workflows/jarbuild.yml
@@ -488,30 +488,71 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout arrow-java repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Checkout Apache Arrow C++ repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: ${{github.event.inputs.arrow_repo}}
+          ref: ${{github.event.inputs.arrow_branch}}
+          path: arrow
+      - name: Get commit IDs
+        id: commit_ids
+        run: |
+          # Get short commit ID for arrow-java
+          arrow_java_commit=$(git rev-parse --short HEAD)
+          echo "arrow_java_commit=${arrow_java_commit}" >> $GITHUB_OUTPUT
+
+          # Get short commit ID for arrow
+          cd arrow
+          arrow_commit=$(git rev-parse --short HEAD)
+          echo "arrow_commit=${arrow_commit}" >> $GITHUB_OUTPUT
+          cd ..
+
+          # Parse version from release tag
+          ver=$(echo ${{github.event.inputs.release_tag_name}})
+          version=${ver%-rc*}
+          version=${version#v}
+          rc=${ver#*-rc}
+
+          # Create release name with both commit IDs
+          release_name="${version}-${arrow_java_commit}-${arrow_commit}"
+          release_tag="v${release_name}"
+          echo "release_name=${release_name}" >> $GITHUB_OUTPUT
+          echo "release_tag=${release_tag}" >> $GITHUB_OUTPUT
+          echo "version=${version}" >> $GITHUB_OUTPUT
+          echo "rc=${rc}" >> $GITHUB_OUTPUT
+
+          echo "Arrow Java commit: ${arrow_java_commit}"
+          echo "Arrow commit: ${arrow_commit}"
+          echo "Release tag: ${release_tag}"
       - name: Download release artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           pattern: release-*
           path: artifacts
+      - name: Create and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.commit_ids.outputs.release_tag }}" -m "Release ${{ steps.commit_ids.outputs.release_name }} RC${{ steps.commit_ids.outputs.rc }}"
+          git push origin "${{ steps.commit_ids.outputs.release_tag }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload
         run: |
           # GH-499: How to create release notes?
-          echo "${{github.event.inputs.release_tag_name}}"
-          ver=$(echo ${{github.event.inputs.release_tag_name}})
-          version=${ver%-rc*}
-          version=${version#v}
-          rc=${ver#*-rc}
-          gh release create ${{github.event.inputs.release_tag_name}} \
+          echo "Creating release: ${{ steps.commit_ids.outputs.release_tag }}"
+          gh release create "${{ steps.commit_ids.outputs.release_tag }}" \
             --generate-notes \
             --prerelease \
             --repo ${GITHUB_REPOSITORY} \
-            --title "Apache Arrow Java ${version} RC${rc}" \
-            --verify-tag
+            --title "Apache Arrow Java ${{ steps.commit_ids.outputs.version }} RC${{ steps.commit_ids.outputs.rc }} (arrow-java: ${{ steps.commit_ids.outputs.arrow_java_commit }}, arrow: ${{ steps.commit_ids.outputs.arrow_commit }})"
           # GitHub CLI does not respect their own rate limits
           # https://github.com/cli/cli/issues/9586
           for artifact in artifacts/*/*; do
             sleep 1
-            gh release upload ${{github.event.inputs.release_tag_name}} \
+            gh release upload "${{ steps.commit_ids.outputs.release_tag }}" \
               --repo ${GITHUB_REPOSITORY} \
               $artifact
           done

--- a/.github/workflows/jarbuild.yml
+++ b/.github/workflows/jarbuild.yml
@@ -535,7 +535,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "${{ steps.commit_ids.outputs.release_tag }}" -m "Release ${{ steps.commit_ids.outputs.release_name }} RC${{ steps.commit_ids.outputs.rc }}"
+          git tag -a "${{ steps.commit_ids.outputs.release_tag }}" -m "Release ${{ steps.commit_ids.outputs.release_name }} RC${{ steps.commit_ids.outputs.rc }}" -m "Action URL: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           git push origin "${{ steps.commit_ids.outputs.release_tag }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -544,7 +544,7 @@ jobs:
           # GH-499: How to create release notes?
           echo "Creating release: ${{ steps.commit_ids.outputs.release_tag }}"
           gh release create "${{ steps.commit_ids.outputs.release_tag }}" \
-            --generate-notes \
+            --notes-from-tag \
             --prerelease \
             --repo ${GITHUB_REPOSITORY} \
             --title "Apache Arrow Java ${{ steps.commit_ids.outputs.version }} RC${{ steps.commit_ids.outputs.rc }} (arrow-java: ${{ steps.commit_ids.outputs.arrow_java_commit }}, arrow: ${{ steps.commit_ids.outputs.arrow_commit }})"

--- a/.github/workflows/jarbuild.yml
+++ b/.github/workflows/jarbuild.yml
@@ -544,7 +544,7 @@ jobs:
           # GH-499: How to create release notes?
           echo "Creating release: ${{ steps.commit_ids.outputs.release_tag }}"
           gh release create "${{ steps.commit_ids.outputs.release_tag }}" \
-            --notes-from-tag \
+            -n "Action URL: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
             --prerelease \
             --repo ${GITHUB_REPOSITORY} \
             --title "Apache Arrow Java ${{ steps.commit_ids.outputs.version }} RC${{ steps.commit_ids.outputs.rc }} (arrow-java: ${{ steps.commit_ids.outputs.arrow_java_commit }}, arrow: ${{ steps.commit_ids.outputs.arrow_commit }})"


### PR DESCRIPTION
## What's Changed

Jars will now be named [version]-[date]-[arrow java commit]-[arrow commit] For example: 18.3.0-20260205010959-5465738-095727a-dremio.

This will allow easier tracing back to the specific commits in arrow and arrow-java.
The release/tag name will now be generated from the input so you no longer need to worry about that as part of the jarbuild stage. It will include the two commit ids and will therefore be "unique" for each distinct change. This will preserve artifacts in github for each set of jars.

**When Running the JarBuild Action** just give it a tag name like "v18.3.0" and the process will append the commit ids based on the branches you configured to build.

Example of a release:
https://github.com/lriggs/arrow-java/releases/tag/v18.3.0-436d2d5-095727a
