### PR TITLE
DX-101654: Add codegen classifier jar for arrow-vector. (#1062)

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -45,6 +45,9 @@ but some modules are JNI bindings to the C++ library.
    * - arrow-vector
      - An off-heap reference implementation for Arrow columnar data format.
      - Native
+   * - arrow-vector-codegen
+     - Template files for Arrow datatypes suitable for code generation.
+     - Native
    * - arrow-tools
      - Java applications for working with Arrow ValueVectors.
      - Native

--- a/vector/pom.xml
+++ b/vector/pom.xml
@@ -202,6 +202,34 @@ under the License.
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>codegen-jar</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <!-- Arrow's type system has many types, and projects building operations across Arrow data
+              (comparisons, casts, aggregations) benefit from generating type-specialized code rather
+              than hand-writing implementations for each type.
+              The TDD files provide a machine-readable definition of Arrow's types that enables this.
+              Including them in the distribution allows downstream projects to generate code that
+              stays in sync as Arrow's type system evolves.-->
+              <classifier>codegen</classifier>
+              <classesDirectory>${basedir}/src/main/codegen</classesDirectory>
+              <includes>
+                <include>**/*.tdd</include>
+                <include>**/*.fmpp</include>
+                <include>**/*.ftl</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
## What's Changed

Add a new codegen classifier jar for arrow-vector that contains tdd and other template files.

Closes #1061 .

