### PR TITLE
Update release tag name

### DIFF
--- a/.github/workflows/jarbuild.yml
+++ b/.github/workflows/jarbuild.yml
@@ -563,7 +563,7 @@ jobs:
           # GH-499: How to create release notes?
           echo "Creating release: ${{ steps.commit_ids.outputs.release_tag }}"
           gh release create "${{ steps.commit_ids.outputs.release_tag }}" \
-            -n "Release ${{ steps.commit_ids.outputs.release_name }} RC${{ steps.commit_ids.outputs.rc }}<br>Triggered by: ${{ github.actor }}<br>Action URL: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID<br>arrow_branch: ${{github.event.inputs.ARROW_BRANCH}}<br>arrow_repo: ${{github.event.inputs.ARROW_REPO}}<br>release_tag_name: ${{github.event.inputs.RELEASE_TAG_NAME}}<br>arrow-java branch: ${{github.ref_name}}" \
+            -n "Release ${{ steps.commit_ids.outputs.release_name }} RC${{ steps.commit_ids.outputs.rc }}<br>Triggered by: ${{ github.actor }}<br>Action URL: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID<br>arrow_branch: ${{github.event.inputs.ARROW_BRANCH}}<br>arrow_repo: ${{github.event.inputs.ARROW_REPO}}<br>arrow-java branch: ${{github.ref_name}}<br>release_tag_name: ${{ steps.commit_ids.outputs.release_tag }}" \
             --prerelease \
             --repo ${GITHUB_REPOSITORY} \
             --title "Apache Arrow Java ${{ steps.commit_ids.outputs.version }} RC${{ steps.commit_ids.outputs.rc }} (arrow-java: ${{ steps.commit_ids.outputs.arrow_java_commit }}, arrow: ${{ steps.commit_ids.outputs.arrow_commit }})"


### PR DESCRIPTION
## What's Changed

Update the release tag information for clarity.

For example:

[Apache Arrow Java 19.1.0 RC2 (arrow-java: d7b7851, arrow: d7b08e8)](https://github.com/lriggs/arrow-java/releases/tag/v19.1.0-d7b7851-d7b08e8) Pre-release
Release 19.1.0-d7b7851-d7b08e8 RC2
Triggered by: lriggs
Action URL: https://github.com/lriggs/arrow-java/actions/runs/23767094203
arrow_branch: dremio_27.0_23_19
arrow_repo: lriggs/arrow
arrow-java branch: dremio_27.0_23_19
release_tag_name: v19.1.0-d7b7851-d7b08e8