### PR TITLE
MINOR: Preserve empty list offsets during split transfers

### DIFF
--- a/.github/workflows/jarbuild.yml
+++ b/.github/workflows/jarbuild.yml
@@ -16,7 +16,7 @@
 # under the License.
 
 name: JarBuild
-on: 
+on:
   workflow_dispatch:
     inputs:
       arrow_branch:

--- a/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
@@ -305,15 +305,27 @@ public class LargeListVector extends BaseValueVector
 
   /** Set the reader and writer indexes for the inner buffers. */
   private void setReaderAndWriterIndex() {
+    final long requiredOffsetBufferCapacity = (long) (valueCount + 1) * OFFSET_WIDTH;
     validityBuffer.readerIndex(0);
     offsetBuffer.readerIndex(0);
     if (valueCount == 0) {
       validityBuffer.writerIndex(0);
-      offsetBuffer.writerIndex(0);
+      ensureEmptyOffsetBufferCapacity(requiredOffsetBufferCapacity);
     } else {
       validityBuffer.writerIndex(getValidityBufferSizeFromCount(valueCount));
-      offsetBuffer.writerIndex((valueCount + 1) * OFFSET_WIDTH);
     }
+    // IPC serializers use readerIndex and writerIndex to determine readable bytes. Even when the
+    // list is empty, the Arrow layout requires the offset buffer to contain offset[0].
+    offsetBuffer.writerIndex(requiredOffsetBufferCapacity);
+  }
+
+  private void ensureEmptyOffsetBufferCapacity(long requiredCapacity) {
+    if (offsetBuffer.capacity() >= requiredCapacity) {
+      return;
+    }
+    ArrowBuf oldOffsetBuffer = offsetBuffer;
+    offsetBuffer = allocateOffsetBuffer(requiredCapacity);
+    oldOffsetBuffer.getReferenceManager().release();
   }
 
   /**

--- a/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
@@ -323,8 +323,10 @@ public class LargeListVector extends BaseValueVector
     if (offsetBuffer.capacity() >= requiredCapacity) {
       return;
     }
+    long previousOffsetAllocationSizeInBytes = offsetAllocationSizeInBytes;
     ArrowBuf oldOffsetBuffer = offsetBuffer;
     offsetBuffer = allocateOffsetBuffer(requiredCapacity);
+    offsetAllocationSizeInBytes = previousOffsetAllocationSizeInBytes;
     oldOffsetBuffer.getReferenceManager().release();
   }
 

--- a/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
@@ -686,24 +686,30 @@ public class LargeListVector extends BaseValueVector
           startIndex,
           length,
           valueCount);
-      final long startPoint = offsetBuffer.getLong((long) startIndex * OFFSET_WIDTH);
-      final long sliceLength =
-          offsetBuffer.getLong((long) (startIndex + length) * OFFSET_WIDTH) - startPoint;
       to.clear();
-      to.offsetBuffer = to.allocateOffsetBuffer((length + 1) * OFFSET_WIDTH);
-      /* splitAndTransfer offset buffer */
-      for (int i = 0; i < length + 1; i++) {
-        final long relativeOffset =
-            offsetBuffer.getLong((long) (startIndex + i) * OFFSET_WIDTH) - startPoint;
-        to.offsetBuffer.setLong((long) i * OFFSET_WIDTH, relativeOffset);
+      if (length > 0) {
+        final long startPoint = offsetBuffer.getLong((long) startIndex * OFFSET_WIDTH);
+        final long sliceLength =
+            offsetBuffer.getLong((long) (startIndex + length) * OFFSET_WIDTH) - startPoint;
+        to.offsetBuffer = to.allocateOffsetBuffer((length + 1) * OFFSET_WIDTH);
+        /* splitAndTransfer offset buffer */
+        for (int i = 0; i < length + 1; i++) {
+          final long relativeOffset =
+              offsetBuffer.getLong((long) (startIndex + i) * OFFSET_WIDTH) - startPoint;
+          to.offsetBuffer.setLong((long) i * OFFSET_WIDTH, relativeOffset);
+        }
+        /* splitAndTransfer validity buffer */
+        splitAndTransferValidityBuffer(startIndex, length, to);
+        /* splitAndTransfer data buffer */
+        dataTransferPair.splitAndTransfer(
+            checkedCastToInt(startPoint), checkedCastToInt(sliceLength));
+        to.lastSet = length - 1;
+        to.setValueCount(length);
+      } else {
+        to.ensureEmptyOffsetBufferCapacity(OFFSET_WIDTH);
+        dataTransferPair.splitAndTransfer(0, 0);
+        to.setValueCount(0);
       }
-      /* splitAndTransfer validity buffer */
-      splitAndTransferValidityBuffer(startIndex, length, to);
-      /* splitAndTransfer data buffer */
-      dataTransferPair.splitAndTransfer(
-          checkedCastToInt(startPoint), checkedCastToInt(sliceLength));
-      to.lastSet = length - 1;
-      to.setValueCount(length);
     }
 
     /*

--- a/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -263,15 +263,27 @@ public class ListVector extends BaseRepeatedValueVector
 
   /** Set the reader and writer indexes for the inner buffers. */
   private void setReaderAndWriterIndex() {
+    final long requiredOffsetBufferCapacity = (long) (valueCount + 1) * OFFSET_WIDTH;
     validityBuffer.readerIndex(0);
     offsetBuffer.readerIndex(0);
     if (valueCount == 0) {
       validityBuffer.writerIndex(0);
-      offsetBuffer.writerIndex(0);
+      ensureEmptyOffsetBufferCapacity(requiredOffsetBufferCapacity);
     } else {
       validityBuffer.writerIndex(getValidityBufferSizeFromCount(valueCount));
-      offsetBuffer.writerIndex((valueCount + 1) * OFFSET_WIDTH);
     }
+    // IPC serializers use readerIndex and writerIndex to determine readable bytes. Even when the
+    // list is empty, the Arrow layout requires the offset buffer to contain offset[0].
+    offsetBuffer.writerIndex(requiredOffsetBufferCapacity);
+  }
+
+  private void ensureEmptyOffsetBufferCapacity(long requiredCapacity) {
+    if (offsetBuffer.capacity() >= requiredCapacity) {
+      return;
+    }
+    ArrowBuf oldOffsetBuffer = offsetBuffer;
+    offsetBuffer = allocateOffsetBuffer(requiredCapacity);
+    oldOffsetBuffer.getReferenceManager().release();
   }
 
   /**

--- a/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -281,8 +281,10 @@ public class ListVector extends BaseRepeatedValueVector
     if (offsetBuffer.capacity() >= requiredCapacity) {
       return;
     }
+    long previousOffsetAllocationSizeInBytes = offsetAllocationSizeInBytes;
     ArrowBuf oldOffsetBuffer = offsetBuffer;
     offsetBuffer = allocateOffsetBuffer(requiredCapacity);
+    offsetAllocationSizeInBytes = previousOffsetAllocationSizeInBytes;
     oldOffsetBuffer.getReferenceManager().release();
   }
 

--- a/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -584,6 +584,10 @@ public class ListVector extends BaseRepeatedValueVector
         dataTransferPair.splitAndTransfer(startPoint, sliceLength);
         to.lastSet = length - 1;
         to.setValueCount(length);
+      } else {
+        to.ensureEmptyOffsetBufferCapacity(OFFSET_WIDTH);
+        dataTransferPair.splitAndTransfer(0, 0);
+        to.setValueCount(0);
       }
     }
 

--- a/vector/src/test/java/org/apache/arrow/vector/TestLargeListVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestLargeListVector.java
@@ -976,6 +976,39 @@ public class TestLargeListVector {
     }
   }
 
+  @Test
+  public void testSplitAndTransferEmptyLargeListAllocatesOffsetBuffer() {
+    try (LargeListVector fromVector = LargeListVector.empty("fromVector", allocator);
+        LargeListVector toVector = LargeListVector.empty("toVector", allocator)) {
+      fromVector.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+      fromVector.allocateNew();
+      fromVector.setValueCount(0);
+
+      TransferPair transferPair = fromVector.makeTransferPair(toVector);
+      transferPair.splitAndTransfer(0, 0);
+
+      assertAllocatedEmptyLargeListOffsetBuffer(toVector);
+    }
+  }
+
+  @Test
+  public void testSplitAndTransferEmptyNestedLargeListAllocatesOffsetBuffers() {
+    try (LargeListVector fromVector = LargeListVector.empty("fromVector", allocator);
+        LargeListVector toVector = LargeListVector.empty("toVector", allocator)) {
+      fromVector.addOrGetVector(FieldType.nullable(MinorType.LARGELIST.getType()));
+      LargeListVector childVector = (LargeListVector) fromVector.getDataVector();
+      childVector.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+      fromVector.allocateNew();
+      fromVector.setValueCount(0);
+
+      TransferPair transferPair = fromVector.makeTransferPair(toVector);
+      transferPair.splitAndTransfer(0, 0);
+
+      assertAllocatedEmptyLargeListOffsetBuffer(toVector);
+      assertAllocatedEmptyLargeListOffsetBuffer((LargeListVector) toVector.getDataVector());
+    }
+  }
+
   private ArrowBuf assertEmptyLargeListOffsetBuffer(LargeListVector list) {
     List<ArrowBuf> buffers = list.getFieldBuffers();
     ArrowBuf offsetBuffer = buffers.get(1);
@@ -983,6 +1016,12 @@ public class TestLargeListVector {
     assertTrue(offsetBuffer.capacity() >= LargeListVector.OFFSET_WIDTH);
     assertEquals(0L, offsetBuffer.getLong(0));
     return offsetBuffer;
+  }
+
+  private void assertAllocatedEmptyLargeListOffsetBuffer(LargeListVector list) {
+    ArrowBuf offsetBuffer = list.getOffsetBuffer();
+    assertTrue(offsetBuffer.capacity() >= LargeListVector.OFFSET_WIDTH);
+    assertEquals(0L, offsetBuffer.getLong(0));
   }
 
   @Test

--- a/vector/src/test/java/org/apache/arrow/vector/TestLargeListVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestLargeListVector.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import io.netty.buffer.NettyArrowBuf;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.complex.BaseRepeatedValueVector;
@@ -953,6 +954,38 @@ public class TestLargeListVector {
         assertEquals(expectedSize, vector.getBufferSizeFor(valueCount));
       }
     }
+  }
+
+  @Test
+  public void testEmptyLargeListOffsetBuffer() {
+    try (LargeListVector list = LargeListVector.empty("list", allocator)) {
+      list.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+      list.allocateNew();
+      list.setValueCount(0);
+
+      assertEmptyLargeListOffsetBuffer(list);
+    }
+  }
+
+  @Test
+  public void testUnallocatedEmptyLargeListOffsetBufferCanBeUnwrappedAsNettyBuffer() {
+    try (LargeListVector list = LargeListVector.empty("list", allocator)) {
+      list.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+      list.setValueCount(0);
+
+      ArrowBuf offsetBuffer = assertEmptyLargeListOffsetBuffer(list);
+      NettyArrowBuf nettyBuffer = NettyArrowBuf.unwrapBuffer(offsetBuffer);
+      assertEquals(LargeListVector.OFFSET_WIDTH, nettyBuffer.readableBytes());
+    }
+  }
+
+  private ArrowBuf assertEmptyLargeListOffsetBuffer(LargeListVector list) {
+    List<ArrowBuf> buffers = list.getFieldBuffers();
+    ArrowBuf offsetBuffer = buffers.get(1);
+    assertEquals(LargeListVector.OFFSET_WIDTH, offsetBuffer.readableBytes());
+    assertTrue(offsetBuffer.capacity() >= LargeListVector.OFFSET_WIDTH);
+    assertEquals(0L, offsetBuffer.getLong(0));
+    return offsetBuffer;
   }
 
   @Test

--- a/vector/src/test/java/org/apache/arrow/vector/TestLargeListVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestLargeListVector.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import io.netty.buffer.NettyArrowBuf;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.complex.BaseRepeatedValueVector;
@@ -968,14 +967,12 @@ public class TestLargeListVector {
   }
 
   @Test
-  public void testUnallocatedEmptyLargeListOffsetBufferCanBeUnwrappedAsNettyBuffer() {
+  public void testUnallocatedEmptyLargeListOffsetBuffer() {
     try (LargeListVector list = LargeListVector.empty("list", allocator)) {
       list.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
       list.setValueCount(0);
 
-      ArrowBuf offsetBuffer = assertEmptyLargeListOffsetBuffer(list);
-      NettyArrowBuf nettyBuffer = NettyArrowBuf.unwrapBuffer(offsetBuffer);
-      assertEquals(LargeListVector.OFFSET_WIDTH, nettyBuffer.readableBytes());
+      assertEmptyLargeListOffsetBuffer(list);
     }
   }
 

--- a/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import io.netty.buffer.NettyArrowBuf;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.AutoCloseables;
@@ -1133,6 +1134,38 @@ public class TestListVector {
         assertEquals(expectedSize, vector.getBufferSizeFor(valueCount));
       }
     }
+  }
+
+  @Test
+  public void testEmptyListOffsetBuffer() {
+    try (ListVector list = ListVector.empty("list", allocator)) {
+      list.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+      list.allocateNew();
+      list.setValueCount(0);
+
+      assertEmptyListOffsetBuffer(list);
+    }
+  }
+
+  @Test
+  public void testUnallocatedEmptyListOffsetBufferCanBeUnwrappedAsNettyBuffer() {
+    try (ListVector list = ListVector.empty("list", allocator)) {
+      list.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+      list.setValueCount(0);
+
+      ArrowBuf offsetBuffer = assertEmptyListOffsetBuffer(list);
+      NettyArrowBuf nettyBuffer = NettyArrowBuf.unwrapBuffer(offsetBuffer);
+      assertEquals(BaseRepeatedValueVector.OFFSET_WIDTH, nettyBuffer.readableBytes());
+    }
+  }
+
+  private ArrowBuf assertEmptyListOffsetBuffer(ListVector list) {
+    List<ArrowBuf> buffers = list.getFieldBuffers();
+    ArrowBuf offsetBuffer = buffers.get(1);
+    assertEquals(BaseRepeatedValueVector.OFFSET_WIDTH, offsetBuffer.readableBytes());
+    assertTrue(offsetBuffer.capacity() >= BaseRepeatedValueVector.OFFSET_WIDTH);
+    assertEquals(0, offsetBuffer.getInt(0));
+    return offsetBuffer;
   }
 
   @Test

--- a/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
@@ -26,7 +26,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import io.netty.buffer.NettyArrowBuf;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.AutoCloseables;
@@ -1148,14 +1147,12 @@ public class TestListVector {
   }
 
   @Test
-  public void testUnallocatedEmptyListOffsetBufferCanBeUnwrappedAsNettyBuffer() {
+  public void testUnallocatedEmptyListOffsetBuffer() {
     try (ListVector list = ListVector.empty("list", allocator)) {
       list.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
       list.setValueCount(0);
 
-      ArrowBuf offsetBuffer = assertEmptyListOffsetBuffer(list);
-      NettyArrowBuf nettyBuffer = NettyArrowBuf.unwrapBuffer(offsetBuffer);
-      assertEquals(BaseRepeatedValueVector.OFFSET_WIDTH, nettyBuffer.readableBytes());
+      assertEmptyListOffsetBuffer(list);
     }
   }
 

--- a/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
@@ -1156,6 +1156,39 @@ public class TestListVector {
     }
   }
 
+  @Test
+  public void testSplitAndTransferEmptyListAllocatesOffsetBuffer() {
+    try (ListVector fromVector = ListVector.empty("fromVector", allocator);
+        ListVector toVector = ListVector.empty("toVector", allocator)) {
+      fromVector.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+      fromVector.allocateNew();
+      fromVector.setValueCount(0);
+
+      TransferPair transferPair = fromVector.makeTransferPair(toVector);
+      transferPair.splitAndTransfer(0, 0);
+
+      assertAllocatedEmptyListOffsetBuffer(toVector);
+    }
+  }
+
+  @Test
+  public void testSplitAndTransferEmptyNestedListAllocatesOffsetBuffers() {
+    try (ListVector fromVector = ListVector.empty("fromVector", allocator);
+        ListVector toVector = ListVector.empty("toVector", allocator)) {
+      fromVector.addOrGetVector(FieldType.nullable(MinorType.LIST.getType()));
+      ListVector childVector = (ListVector) fromVector.getDataVector();
+      childVector.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+      fromVector.allocateNew();
+      fromVector.setValueCount(0);
+
+      TransferPair transferPair = fromVector.makeTransferPair(toVector);
+      transferPair.splitAndTransfer(0, 0);
+
+      assertAllocatedEmptyListOffsetBuffer(toVector);
+      assertAllocatedEmptyListOffsetBuffer((ListVector) toVector.getDataVector());
+    }
+  }
+
   private ArrowBuf assertEmptyListOffsetBuffer(ListVector list) {
     List<ArrowBuf> buffers = list.getFieldBuffers();
     ArrowBuf offsetBuffer = buffers.get(1);
@@ -1163,6 +1196,12 @@ public class TestListVector {
     assertTrue(offsetBuffer.capacity() >= BaseRepeatedValueVector.OFFSET_WIDTH);
     assertEquals(0, offsetBuffer.getInt(0));
     return offsetBuffer;
+  }
+
+  private void assertAllocatedEmptyListOffsetBuffer(ListVector list) {
+    ArrowBuf offsetBuffer = list.getOffsetBuffer();
+    assertTrue(offsetBuffer.capacity() >= BaseRepeatedValueVector.OFFSET_WIDTH);
+    assertEquals(0, offsetBuffer.getInt(0));
   }
 
   @Test

--- a/vector/src/test/java/org/apache/arrow/vector/TestSplitAndTransfer.java
+++ b/vector/src/test/java/org/apache/arrow/vector/TestSplitAndTransfer.java
@@ -111,13 +111,16 @@ public class TestSplitAndTransfer {
   @Test
   public void testWithEmptyVector() {
     // MapVector use TransferImpl from ListVector
-    ListVector listVector = ListVector.empty("", allocator);
-    TransferPair transferPair = listVector.getTransferPair(allocator);
-    transferPair.splitAndTransfer(0, 0);
-    assertEquals(0, transferPair.getTo().getValueCount());
+    try (ListVector listVector = ListVector.empty("", allocator)) {
+      TransferPair transferPair = listVector.getTransferPair(allocator);
+      try (ValueVector toVector = transferPair.getTo()) {
+        transferPair.splitAndTransfer(0, 0);
+        assertEquals(0, toVector.getValueCount());
+      }
+    }
     // BaseFixedWidthVector
     IntVector intVector = new IntVector("", allocator);
-    transferPair = intVector.getTransferPair(allocator);
+    TransferPair transferPair = intVector.getTransferPair(allocator);
     transferPair.splitAndTransfer(0, 0);
     assertEquals(0, transferPair.getTo().getValueCount());
     // BaseVariableWidthVector

--- a/vector/src/test/java/org/apache/arrow/vector/testing/ValueVectorDataPopulator.java
+++ b/vector/src/test/java/org/apache/arrow/vector/testing/ValueVectorDataPopulator.java
@@ -633,10 +633,9 @@ public class ValueVectorDataPopulator {
 
   /** Populate values for {@link ListVector}. */
   public static void setVector(ListVector vector, List<Integer>... values) {
+    vector.allocateNewSafe();
     Types.MinorType type = Types.MinorType.INT;
     vector.addOrGetVector(FieldType.nullable(type.getType()));
-    vector.setInitialCapacity(values.length);
-    vector.allocateNewSafe();
 
     IntVector dataVector = (IntVector) vector.getDataVector();
     dataVector.allocateNew();
@@ -663,10 +662,9 @@ public class ValueVectorDataPopulator {
 
   /** Populate values for {@link LargeListVector}. */
   public static void setVector(LargeListVector vector, List<Integer>... values) {
+    vector.allocateNewSafe();
     Types.MinorType type = Types.MinorType.INT;
     vector.addOrGetVector(FieldType.nullable(type.getType()));
-    vector.setInitialCapacity(values.length);
-    vector.allocateNewSafe();
 
     IntVector dataVector = (IntVector) vector.getDataVector();
     dataVector.allocateNew();

--- a/vector/src/test/java/org/apache/arrow/vector/testing/ValueVectorDataPopulator.java
+++ b/vector/src/test/java/org/apache/arrow/vector/testing/ValueVectorDataPopulator.java
@@ -633,9 +633,10 @@ public class ValueVectorDataPopulator {
 
   /** Populate values for {@link ListVector}. */
   public static void setVector(ListVector vector, List<Integer>... values) {
-    vector.allocateNewSafe();
     Types.MinorType type = Types.MinorType.INT;
     vector.addOrGetVector(FieldType.nullable(type.getType()));
+    vector.setInitialCapacity(values.length);
+    vector.allocateNewSafe();
 
     IntVector dataVector = (IntVector) vector.getDataVector();
     dataVector.allocateNew();
@@ -662,9 +663,10 @@ public class ValueVectorDataPopulator {
 
   /** Populate values for {@link LargeListVector}. */
   public static void setVector(LargeListVector vector, List<Integer>... values) {
-    vector.allocateNewSafe();
     Types.MinorType type = Types.MinorType.INT;
     vector.addOrGetVector(FieldType.nullable(type.getType()));
+    vector.setInitialCapacity(values.length);
+    vector.allocateNewSafe();
 
     IntVector dataVector = (IntVector) vector.getDataVector();
     dataVector.allocateNew();


### PR DESCRIPTION
## What changed

This is stacked on top of dremio/arrow-java#30 and extends the same empty-offset-buffer handling into zero-length `splitAndTransfer()` paths for `ListVector` and `LargeListVector`.

For zero-length splits, the target vector now materializes the required empty offset entry and recursively invokes the child transfer pair with a zero-length range so nested list vectors get the same invariant treatment.

## Why

`splitAndTransfer()` should always return a valid allocated vector. A vector with no entries still needs, by spec, a value of `0` in its `offsetBuffer`; a list vector with a zero-capacity `offsetBuffer` is not valid.

PR 30 is still useful as serialization/export hardening, but this moves the repair closer to where the invalid empty-vector state can be introduced.

One grey area remains: `getFieldBuffers()` triggering allocation for an otherwise unallocated vector is useful as a last-line guard, but it is not the cleanest owner of the allocation invariant.

## Testing

```bash
mvn -pl vector -Dmaven.gitcommitid.skip=true -Dsurefire.failIfNoSpecifiedTests=false -Dtest=TestListVector,TestLargeListVector test
mvn -pl vector spotless:apply
```

Targeted tests passed under both Netty and Unsafe allocator executions.
